### PR TITLE
Add per_page to fix bug

### DIFF
--- a/_posts/2016-09-08-ssh-keys-github.markdown
+++ b/_posts/2016-09-08-ssh-keys-github.markdown
@@ -19,7 +19,7 @@ Recently we decided to improve the way we manage ssh keys on our servers. We're 
 # Solution
 A colleague suggested [this solution][better-ssh]. Using the `AuthorizedKeysCommand` seemed like a perfect solution here. Since public keys of users are available through `https://github.com/<USER>.keys`, we can just download them while trying to connect and override the `authorized_keys` file.
 
-Here is the script we use to get the users from the right teams in our Github organisation :
+Here is the script we use to get the users from the right teams in our Github organisation:
 {% highlight bash %}
 #!/bin/bash
 
@@ -31,7 +31,7 @@ function dl_keys {
 # GITHUB_TEAM is the team UID
 # GITHUB_TOKEN is the token used for authentication
 if [[ ! -z $GITHUB_TEAM && ! -z $GITHUB_TOKEN ]]; then
-  users=$(curl -sf https://api.github.com/teams/${GITHUB_TEAM}/members -H "Authorization: token ${GITHUB_TOKEN}"|jq -r '.[].login')
+  users=$(curl -sf https://api.github.com/teams/${GITHUB_TEAM}/members?per_page=100 -H "Authorization: token ${GITHUB_TOKEN}"|jq -r '.[].login')
 
   for i in $users; do
     dl_keys $i &
@@ -82,7 +82,7 @@ function dl_keys {
 # Function to cache keys to disk
 function cache_keys {
   if [[ ! -z $GITHUB_TEAM && ! -z $GITHUB_TOKEN ]]; then
-    users=$(curl -m 10 -sf https://api.github.com/teams/${GITHUB_TEAM}/members -H "Authorization: token ${GITHUB_TOKEN}"|jq -r '.[].login')
+    users=$(curl -m 10 -sf https://api.github.com/teams/${GITHUB_TEAM}/members?per_page=100 -H "Authorization: token ${GITHUB_TOKEN}"|jq -r '.[].login')
     for i in $users; do
       dl_keys $i >> $cache_file &
     done

--- a/_posts/2016-09-08-ssh-keys-github.markdown
+++ b/_posts/2016-09-08-ssh-keys-github.markdown
@@ -45,6 +45,8 @@ fi
 
 You will need to create a Github authorisation token, to which you can just assign read rights on your organisations and ssh keys.
 
+Note that by default the GitHub API returns 30 items per page for the Team Members endpoint. The maximum items per page in a response is 100, which is more than sufficient for our current needs. If our team member count goes over 100, we will need to add a paging loop to the script above.
+
 Once this script is added to the server, add the following lines to your `/etc/ssh/sshd_config` file :
 
 ```


### PR DESCRIPTION
Default per page limit is 30, increased to the maximum of 100 team members